### PR TITLE
SVG icon for Moodle 3.5

### DIFF
--- a/pix/icon.svg
+++ b/pix/icon.svg
@@ -1,0 +1,1 @@
+<svg id="Ebene_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><style>.st0{fill:#fff}.st0,.st1,.st2{stroke:#000;stroke-miterlimit:10}.st2{fill:#fff;stroke-width:.5}</style><path class="st0" d="M.4 6.4h9.5v3.5H.4z"/><path class="st1" d="M11.9 7.5h3.5v1.7h-3.5z"/><path class="st2" d="M13.7 12.8l-1.1.3 1 2.1-.7.3-1-2.1-1 .6v-3.7z"/></svg>


### PR DESCRIPTION
Starting with Moodle 3.5 for the standard Moodle question types SVG icons have been put in place [https://tracker.moodle.org/browse/MDL-45367](https://tracker.moodle.org/browse/MDL-45367).
This is the SVG icon for qtype_fileresponse.