### PR TITLE
Adding icon class to oversized icon images fixes #2.

### DIFF
--- a/fileresponsefilemanager.php
+++ b/fileresponsefilemanager.php
@@ -645,13 +645,13 @@ class qtype_fileresponse_fileresponsefilemanager_renderer extends plugin_rendere
             </div>
             <div class="fp-viewbar">
                 <a title="'. get_string('displayicons', 'repository') .'" class="fp-vb-icons" href="#">
-                    <img alt="" src="'. $this->pix_url('fp/view_icon_active', 'theme') .'" />
+                    <img alt="" src="'. $this->pix_url('fp/view_icon_active', 'theme') .'" class="icon"/>
                 </a>
                 <a title="'. get_string('displaydetails', 'repository') .'" class="fp-vb-details" href="#">
-                    <img alt="" src="'. $this->pix_url('fp/view_list_active', 'theme') .'" />
+                    <img alt="" src="'. $this->pix_url('fp/view_list_active', 'theme') .'" class="icon"/>
                 </a>
                 <a title="'. get_string('displaytree', 'repository') .'" class="fp-vb-tree" href="#">
-                    <img alt="" src="'. $this->pix_url('fp/view_tree_active', 'theme') .'" />
+                    <img alt="" src="'. $this->pix_url('fp/view_tree_active', 'theme') .'" class="icon"/>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
This fixes the absurd 1792x1792 px sized svg images displayed in Boost based themes.
Note there is the need to rework this question type entirely and make it a new clone of the nowaday essay question type, using mustache templates and so on.