### PR TITLE
Fix error of wrong format

### DIFF
--- a/renderer.php
+++ b/renderer.php
@@ -385,7 +385,7 @@ class qtype_fileresponse_renderer extends qtype_renderer {
 
         $question = $qa->get_question();
         return html_writer::nonempty_tag('div',
-                $question->format_text($question->graderinfo, $question->graderinfo, $qa,
+                $question->format_text($question->graderinfo, $question->questiontextformat, $qa,
                         'qtype_fileresponse', 'graderinfo', $question->id),
                 array('class' => 'graderinfo'
                 ));


### PR DESCRIPTION
In the manual grading process, there was an error when clicking on a submitted file.
The reason was that format_text() requires the format constant in the secound parameter. Instead the text to format was given again.